### PR TITLE
Added Requirements.txt and Changed the deprecated ANTIALIAS to LANCZOS

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,37 +23,37 @@ label_title.grid(pady=(10,10), column=2)
 
 
 icon = Image.open('icons/spy.png')
-icon = icon.resize((150,150), Image.ANTIALIAS)
+icon = icon.resize((150,150), Image.LANCZOS)
 icon = ImageTk.PhotoImage(icon)
 label_icon = tk.Label(frame1, image=icon)
 label_icon.grid(row=1, pady=(5,10), column=2)
 
 btn1_image = Image.open('icons/lamp.png')
-btn1_image = btn1_image.resize((50,50), Image.ANTIALIAS)
+btn1_image = btn1_image.resize((50,50), Image.LANCZOS)
 btn1_image = ImageTk.PhotoImage(btn1_image)
 
 btn2_image = Image.open('icons/rectangle-of-cutted-line-geometrical-shape.png')
-btn2_image = btn2_image.resize((50,50), Image.ANTIALIAS)
+btn2_image = btn2_image.resize((50,50), Image.LANCZOS)
 btn2_image = ImageTk.PhotoImage(btn2_image)
 
 btn5_image = Image.open('icons/exit.png')
-btn5_image = btn5_image.resize((50,50), Image.ANTIALIAS)
+btn5_image = btn5_image.resize((50,50), Image.LANCZOS)
 btn5_image = ImageTk.PhotoImage(btn5_image)
 
 btn3_image = Image.open('icons/security-camera.png')
-btn3_image = btn3_image.resize((50,50), Image.ANTIALIAS)
+btn3_image = btn3_image.resize((50,50), Image.LANCZOS)
 btn3_image = ImageTk.PhotoImage(btn3_image)
 
 btn6_image = Image.open('icons/incognito.png')
-btn6_image = btn6_image.resize((50,50), Image.ANTIALIAS)
+btn6_image = btn6_image.resize((50,50), Image.LANCZOS)
 btn6_image = ImageTk.PhotoImage(btn6_image)
 
 btn4_image = Image.open('icons/recording.png')
-btn4_image = btn4_image.resize((50,50), Image.ANTIALIAS)
+btn4_image = btn4_image.resize((50,50), Image.LANCZOS)
 btn4_image = ImageTk.PhotoImage(btn4_image)
 
 btn7_image = Image.open('icons/recording.png')
-btn7_image = btn7_image.resize((50,50), Image.ANTIALIAS)
+btn7_image = btn7_image.resize((50,50), Image.LANCZOS)
 btn7_image = ImageTk.PhotoImage(btn7_image)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+beepy-web==0.8.9
+boltons==23.1.1
+imageio==2.33.1
+lazy_loader==0.3
+micropip==0.6.0
+networkx==3.2.1
+numpy==1.26.4
+opencv-python==4.9.0.80
+packaging==23.2
+pillow==10.2.0
+pyodide-py==0.24.1
+python-dotenv==1.0.0
+scikit-image==0.22.0
+scipy==1.12.0
+tifffile==2024.1.30


### PR DESCRIPTION
### Added requirements.txt
* Now one can install all the dependencies with `pip install -r requirements.txt`
* This will help prevent anyone from manually installing it.

### Changed the deprecated Image.ANTIALIAS to Image.LANCZOS
* It is deprecated so this is the same algorithm with new name
* This will avoid running into the `AttributeError: Image has not attribute ANTIALIAS`